### PR TITLE
fail Travis build if tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,13 @@ branches:
 install:
   - pip install pytest coverage codacy-coverage
 script:
+  - set -e
   - printenv
   - ls -la
   - coverage run -m py.test tests
   - coverage xml
   - python-codacy-coverage -r coverage.xml
+  - set +e
 deploy:
   provider: pypi
   user: devopshq


### PR DESCRIPTION
Currently, due to a bug in Travis-CI, the build won't fail
unless the last command in the script directive fails.

This means that if the lint or tests or coverage fail, the
Travis CI build itself won't fail, in turn giving the false
sense that everything is OK and the PR can be merged.

In order to work around this Travis CI limitation we need
to explicitly ask for the shell to exit with an error
immediately if a command exits with a non-zero status.
(set -e)